### PR TITLE
fix_repos plugin: fix outdated repositories and add i386 package support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# http://travis-ci.org/#!/ricrogz/StarClusterPlugins
+language: python
+python:
+    - 2.6
+    - 2.7
+install:
+    - python setup.py install --quiet
+script:
+    - python setup.py test --coverage

--- a/starcluster/plugins/extras/fix_repos.py
+++ b/starcluster/plugins/extras/fix_repos.py
@@ -1,0 +1,26 @@
+from starcluster import clustersetup
+from starcluster.logger import log
+
+class RepoFixer(clustersetup.DefaultClusterSetup):
+
+    def __init__(self):
+        super(RepoFixer, self).__init__()
+        log.info('Initializing Repository Fixer plugin')
+
+        self.commands = [
+            "sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g;s/us-east-1.ec2.//g' /etc/apt/sources.list",
+            "dpkg --add-architecture i386"
+        ]
+
+    def run(self, nodes, master, user, user_shell, volumes):
+        log.info('Fixing outdated repos & adding i386 architecture in cluster.')
+        for node in nodes:
+            self.pool.simple_job(node.ssh.execute, (" && ".join(self.commands)), jobid=node.alias)
+        self.pool.wait(len(nodes))
+
+    def on_add_node(self, new_node, nodes, master, user, user_shell, volumes):
+        log.info('Fixing outdated repos & adding i386 architecture on node %s.' % new_node.alias)
+        new_node.ssh.execute(" && ".join(self.commands))
+
+    def on_remove_node(self, node, nodes, master, user, user_shell, volumes):
+        raise NotImplementedError('on_remove_node method not implemented')


### PR DESCRIPTION
Latest official starcluster AMIs are made from Ubuntu 13.04, which is already outdated, and package repositories are no longer available under the default URLs. This plugin automatically fixes /etc/apt/source.list to point to 'old-releases.ubuntu.com', which still holds compatible packages.

It also adds support for i386 packages, which is not enabled on x86_64 AMIs (at least not on ami-6b211202).

I'm realatively new to starcluster, and this is my first try at plugin development: any comments and/or suggestions will be welcome.
